### PR TITLE
Change Eero.reboot() to also accept a resource URL

### DIFF
--- a/eero/eero.py
+++ b/eero/eero.py
@@ -81,5 +81,6 @@ class Eero(object):
 
     def reboot(self, device_id):
         return self.refreshed(lambda: self.client.post(
-                                        'eeros/{}/reboot'.format(device_id),
+                                        'eeros/{}/reboot'.format(
+                                            self.id_from_url(device_id)),
                                         cookies=self._cookie_dict))


### PR DESCRIPTION
First, thanks for making this great library!

Most of the methods in the `Eero` class, like `Eero.networks`, `Eero.devices` and `Eero.eeros`, allow passing a resource URL like `/2.2/networks/123456`.

However, the `Eero.reboot` method does not, and requires the caller to first extract the Eero device ID from a resource URL like `/2.2/eeros/1234567` with `Eero.id_from_url()`.

Since this feels rather inconsistent, this commit changes the `Eero.reboot` method to also allow directly passing in a resource URL.